### PR TITLE
Remove unused pyobjc dependencies

### DIFF
--- a/ai_meeting_assistant/requirements.txt
+++ b/ai_meeting_assistant/requirements.txt
@@ -180,11 +180,6 @@ pyinstaller==6.14.2
 pyinstaller-hooks-contrib==2025.6
 PyJWT==2.10.1
 pymdown-extensions==10.16
-pyobjc-core==11.1
-pyobjc-framework-Cocoa==11.1
-pyobjc-framework-Quartz==11.1
-pyobjc-framework-Security==11.1
-pyobjc-framework-WebKit==11.1
 pyparsing==3.2.3
 pypdf==5.8.0
 PyPDF2==3.0.1

--- a/ai_meeting_assistant/src/ai_meeting_assistant/requirements.txt
+++ b/ai_meeting_assistant/src/ai_meeting_assistant/requirements.txt
@@ -180,11 +180,6 @@ pyinstaller==6.14.2
 pyinstaller-hooks-contrib==2025.6
 PyJWT==2.10.1
 pymdown-extensions==10.16
-pyobjc-core==11.1
-pyobjc-framework-Cocoa==11.1
-pyobjc-framework-Quartz==11.1
-pyobjc-framework-Security==11.1
-pyobjc-framework-WebKit==11.1
 pyparsing==3.2.3
 pypdf==5.8.0
 PyPDF2==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -180,11 +180,6 @@ pyinstaller==6.14.2
 pyinstaller-hooks-contrib==2025.6
 PyJWT==2.10.1
 pymdown-extensions==10.16
-pyobjc-core==11.1
-pyobjc-framework-Cocoa==11.1
-pyobjc-framework-Quartz==11.1
-pyobjc-framework-Security==11.1
-pyobjc-framework-WebKit==11.1
 pyparsing==3.2.3
 pypdf==5.8.0
 PyPDF2==3.0.1


### PR DESCRIPTION
## Summary
- drop macOS-specific `pyobjc` packages from all requirements files

## Testing
- `pip install -r requirements.txt --dry-run` *(fails: crewai-tools 0.55.0 depends on crewai>=0.140.0)*

------
https://chatgpt.com/codex/tasks/task_b_688f662cfc2c832e8ba3dbb9bf414da0