### PR TITLE
Ensure compatible SQLite for Streamlit Cloud

### DIFF
--- a/ai_meeting_assistant/requirements.txt
+++ b/ai_meeting_assistant/requirements.txt
@@ -7,3 +7,4 @@ python-docx==1.2.0
 pandas==2.3.0
 PyYAML==6.0.2
 python-dotenv==1.1.1
+pysqlite3-binary==0.5.4

--- a/ai_meeting_assistant/src/ai_meeting_assistant/crew.py
+++ b/ai_meeting_assistant/src/ai_meeting_assistant/crew.py
@@ -1,3 +1,8 @@
+import pysqlite3  # ensures SQLite ≥3.35
+import sys
+
+sys.modules["sqlite3"] = pysqlite3
+
 import os
 import yaml
 from dotenv import load_dotenv

--- a/ai_meeting_assistant/src/ai_meeting_assistant/requirements.txt
+++ b/ai_meeting_assistant/src/ai_meeting_assistant/requirements.txt
@@ -7,3 +7,4 @@ python-docx==1.2.0
 pandas==2.3.0
 PyYAML==6.0.2
 python-dotenv==1.1.1
+pysqlite3-binary==0.5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-docx==1.2.0
 pandas==2.3.0
 PyYAML==6.0.2
 python-dotenv==1.1.1
+pysqlite3-binary==0.5.4


### PR DESCRIPTION
## Summary
- Add `pysqlite3-binary` to all requirement files so Streamlit Cloud builds with a modern SQLite runtime.
- Load `pysqlite3` before importing `crewai` to avoid Chromadb SQLite version errors.

## Testing
- `python3 -m py_compile ai_meeting_assistant/src/ai_meeting_assistant/crew.py`
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688f6f2a0c3c832e9f8fa87d92530184